### PR TITLE
feat: Upgrade to v0.5.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TeaserPaste CLI (`tp`)
 **TeaserPaste CLI** (`tp`) là một công cụ dòng lệnh mạnh mẽ giúp bạn tương tác với dịch vụ [TeaserPaste](https://paste.teaserverse.online) trực tiếp từ terminal. Dễ dàng xem, tạo, và quản lý snippets mà không cần rời khỏi môi trường làm việc của bạn.
 
-**Phiên bản hiện tại:** 0.4.0 (Alpha) - *Vui lòng lưu ý rằng các tính năng và cú pháp có thể thay đổi.*
+**Phiên bản hiện tại:** 0.5.0 (Beta) - *Vui lòng lưu ý rằng các tính năng và cú pháp có thể thay đổi.*
 
 # Cài đặt
 
@@ -17,10 +17,13 @@ tp config set token "priv_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 ```
 
 # Hướng dẫn sử dụng nhanh
-Tạo Snippet
+## Tạo và Sao chép Snippet
 ```
 # Cách thân thiện nhất (CLI sẽ hỏi bạn từng bước)
 tp create -i
+
+# Sao chép (fork) một snippet vào tài khoản của bạn
+tp copy <snippet_id> --title "Bản sao của tôi"
 
 # Cách chuyên nghiệp (tạo snippet từ nội dung file)
 cat my_script.js | tp create --title "My Script" --language "javascript"
@@ -29,7 +32,17 @@ cat my_script.js | tp create --title "My Script" --language "javascript"
 tp create --title "Ghi chú" --content "Nội dung ghi chú"
 ```
 
-# Xem và Quản lý Snippet
+## Thực thi Mã từ Snippet
+Thực thi mã trực tiếp từ một snippet. CLI sẽ hiển thị cảnh báo và yêu cầu xác nhận trước khi chạy.
+```
+# Tự động phát hiện ngôn ngữ và chạy (hỗ trợ python, node, bash...)
+tp run <snippet_id>
+
+# Cung cấp lệnh thực thi tùy chỉnh (thay thế --snippet bằng tên file tạm)
+tp run <snippet_id> -- "node --snippet --arg1"
+```
+
+## Xem và Quản lý Snippet
 ```
 # Liệt kê các snippet của bạn
 tp list
@@ -44,10 +57,10 @@ tp view <snippet_id> --raw
 tp view <snippet_id> --copy
 
 # Mở snippet trên trình duyệt
-tp view <snippet_id> --web
+tp view <snippet_id> --url
 
-# Tìm kiếm public snippets
-tp search "javascript example"
+# Tìm kiếm public snippets với phân trang
+tp search "javascript example" --limit 5 --from 10
 
 # Xóa một snippet
 tp delete <snippet_id>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teaserpaste-cli",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "CLI Client for TeaserPaste - View, create, and manage snippets.",
   "main": "cli.js",
   "bin": {
@@ -17,7 +17,8 @@
   "dependencies": {
     "clipboardy": "^5.0.0",
     "inquirer": "^12.9.6",
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^2.6.7",
+    "keytar": "^7.9.0"
   },
   "preferGlobal": true
 }


### PR DESCRIPTION
This commit introduces several new features and improvements to upgrade the `teaserpaste-cli` to version 0.5.0 Beta.

- **feat(copy):** Add `tp copy` command to fork snippets.
- **feat(run):** Add `tp run` command to execute snippets with a security prompt.
- **feat(search):** Update `tp search` for OpenSearch API compatibility and add `--limit` and `--from` flags for pagination.
- **feat(security):** Implement `keytar` for secure token storage in the OS keychain.
- **feat(editor):** Add an optional in-terminal editor for `tp create -i`.
- **chore:** Update `README.md` to reflect the new features and changes.